### PR TITLE
fix: avoid increasing the model number to match the one from the pdb

### DIFF
--- a/biobb_structure_utils/utils/common.py
+++ b/biobb_structure_utils/utils/common.py
@@ -176,7 +176,7 @@ def create_output_file(type, input, residues, output, out_log):
 
 def create_biopython_residue(residue):
     return {
-        "model": str(residue.get_parent().get_parent().get_id() + 1),
+        "model": str(residue.get_parent().get_parent().get_id()),
         "chain": residue.get_parent().get_id(),
         "name": residue.get_resname(),
         "res_id": str(residue.get_id()[1]),


### PR DESCRIPTION
Hi!

As always, I hope I didn't misunderstood something - I know you are very busy :)

I was trying to use the 5.0.0 version of extract_residues to find 3 residues from a PDB file.  [(find the PDB attached)](https://github.com/user-attachments/files/18200625/receptor.zip). This is the residue selection:

```
step_extract_residues:
  tool: extract_residues
  paths:
    input_structure_path: receptor.pdb 
    output_residues_path: pocket_residues.pdb
  properties:
    residues: [{'res_id': '37', 'model':'0'}, {'res_id': '49', 'model':'0'}, {'res_id': '112', 'model':'0'}]                            
```

The std err yields the following:

`ExtractResidues: The residues given by user were not found in input structure`

The fact is that the biobb sums 1 to the model number when building the structure residues to compare with the user selection. We do this in line 179 of common.py:

`        "model": str(residue.get_parent().get_parent().get_id()+1),`

If I change the model of my selection to 1 then the biobb finds the residues (meaning new_structure is not empty, see line 120 in extract_residues.py) but the corresponding output_residues_path is empty. This is because it tries to write residues of model 1 when the only existing model in the input structure is 0. 

I'm not sure of the original reason to add 1 to the model of the residues built using create_biopython_residue(). But applying this change the biobb works as expected and finds the residues from model 0.
